### PR TITLE
Change login form target

### DIFF
--- a/application/templates/userlogin.html
+++ b/application/templates/userlogin.html
@@ -8,7 +8,7 @@
             <div class='error'><h2>{{ error }}</h2></div>
         {% endfor %}
     {% endif %}
-    <form action="/users/authorize">
+    <form action="/users/authorize" target="_blank">
         <input type="image" src="../static/btn_google_signin_light_normal.png" class="googlebtn" />
         <div class="consent">
             <p>


### PR DESCRIPTION
This makes clicking "Login with Google" open a new tab. Once the user is done logging in, the tab remains open, along with the original tab. This could be annoying. However, this does allow for a user to login into the website while in the plugin menu (see the new repository).

Currently, the Change-login-form-target branch is active on wciwalks.herokuapp.com.

@scott-22, what do you think?